### PR TITLE
Fix Clang compatibility

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+*.gch*
+*.pch*
+*.log
+*.out

--- a/gtplib/detail/gtpcodec_impl.hpp
+++ b/gtplib/detail/gtpcodec_impl.hpp
@@ -13,6 +13,7 @@
 #include <memory>
 #include <stdexcept>
 #include <tuple>
+#include <utility>
 #include <boost/algorithm/string.hpp>
 #include <boost/mpl/for_each.hpp>
 
@@ -348,7 +349,7 @@ struct ProcessCommand
     if (commandType != Command::type) return;
      
     Command cmd;
-    typedef decltype(Command::params) Tuple;
+    typedef decltype(std::declval<Command>().params) Tuple;
     ParseAux<std::tuple_size<Tuple>::value> parser;
     parser(args, cmd.params);
     cmd.params;

--- a/gtplib/detail/gtpcodec_impl.hpp
+++ b/gtplib/detail/gtpcodec_impl.hpp
@@ -352,7 +352,6 @@ struct ProcessCommand
     typedef decltype(std::declval<Command>().params) Tuple;
     ParseAux<std::tuple_size<Tuple>::value> parser;
     parser(args, cmd.params);
-    cmd.params;
     result = WhateverCommand (cmd);
   }
 };

--- a/gtplib/detail/gtpcodec_impl.hpp
+++ b/gtplib/detail/gtpcodec_impl.hpp
@@ -403,7 +403,7 @@ struct WriteHelper<std::list<T>>
     for (const T& t : listOfElements)
     {
       helper.writeResponse(output, t);
-      output << " ";
+      output << std::endl;
     }
   }
 }; 

--- a/gtplib/detail/gtpcodec_impl.hpp
+++ b/gtplib/detail/gtpcodec_impl.hpp
@@ -96,11 +96,12 @@ inline std::string command2string (CommandType type)
 
 ///////////////////////////////////////////////////////////////////////////////
 // Dumps a gtp::Vertex to the given output stream
+// (1~19, 1~19)
 //
 inline std::ostream& operator<< (std::ostream& out, const Vertex& v)
 {
   unsigned column = v.y;
-  char row = 'A' + v.x;
+  char row = 'A' + v.x - 1;
   if (row >= 'I')
       ++row; // Special treatment of row. Row is labeled A~H J~T
   out << row << column;
@@ -109,6 +110,7 @@ inline std::ostream& operator<< (std::ostream& out, const Vertex& v)
 
 ///////////////////////////////////////////////////////////////////////////////
 // Parses a gtp::Vertex from the given input stream
+// (1~19, 1~19)
 //
 inline std::istream& operator>>(std::istream& in, Vertex& vertex)
 {
@@ -121,7 +123,7 @@ inline std::istream& operator>>(std::istream& in, Vertex& vertex)
     return in;
   }
 
-  vertex.x = v.at(0) - 'A';
+  vertex.x = v.at(0) - 'A' + 1;
   if (v.at(0) > 'I')
       --vertex.x;
   vertex.y = atoi(&v.c_str()[1]);

--- a/gtplib/detail/gtpcodec_impl.hpp
+++ b/gtplib/detail/gtpcodec_impl.hpp
@@ -101,6 +101,8 @@ inline std::ostream& operator<< (std::ostream& out, const Vertex& v)
 {
   unsigned column = v.y;
   char row = 'A' + v.x;
+  if (row >= 'I')
+      ++row; // Special treatment of row. Row is labeled A~H J~T
   out << row << column;
   return out;
 }
@@ -120,6 +122,8 @@ inline std::istream& operator>>(std::istream& in, Vertex& vertex)
   }
 
   vertex.x = v.at(0) - 'A';
+  if (v.at(0) > 'I')
+      --vertex.x;
   vertex.y = atoi(&v.c_str()[1]);
 
   return in;

--- a/gtplib/detail/gtpcodec_impl.hpp
+++ b/gtplib/detail/gtpcodec_impl.hpp
@@ -12,6 +12,7 @@
 #include <ostream>
 #include <memory>
 #include <stdexcept>
+#include <tuple>
 #include <boost/algorithm/string.hpp>
 #include <boost/mpl/for_each.hpp>
 

--- a/gtplib/detail/gtpcodec_impl.hpp
+++ b/gtplib/detail/gtpcodec_impl.hpp
@@ -136,7 +136,8 @@ inline std::istream& operator>>(std::istream& in, VertexOrPass& vertexOrPass)
 {
   std::string s;
   in >> s;
-  if (s == "pass")
+  boost::to_upper(s);
+  if (s == "PASS")
   {
     vertexOrPass = Pass();
   }

--- a/gtplib/detail/gtpcodec_impl.hpp
+++ b/gtplib/detail/gtpcodec_impl.hpp
@@ -460,7 +460,7 @@ WhateverCommand ProtocolCodec::readCommand ()
 template<typename T> void ProtocolCodec::writeResponse (const T& t)
 {
   WriteHelper<T> helper;
-  output_ << '= ';
+  output_ << "= ";
   helper.writeResponse (output_, t);
   output_ << std::endl << std::endl;
 }

--- a/gtplib/detail/gtpcodec_impl.hpp
+++ b/gtplib/detail/gtpcodec_impl.hpp
@@ -460,8 +460,9 @@ WhateverCommand ProtocolCodec::readCommand ()
 template<typename T> void ProtocolCodec::writeResponse (const T& t)
 {
   WriteHelper<T> helper;
+  output_ << '=';
   helper.writeResponse (output_, t);
-  output_ << std::endl;
+  output_ << std::endl << std::endl;
 }
 
 }

--- a/gtplib/detail/gtpcodec_impl.hpp
+++ b/gtplib/detail/gtpcodec_impl.hpp
@@ -460,7 +460,7 @@ WhateverCommand ProtocolCodec::readCommand ()
 template<typename T> void ProtocolCodec::writeResponse (const T& t)
 {
   WriteHelper<T> helper;
-  output_ << '=';
+  output_ << '= ';
   helper.writeResponse (output_, t);
   output_ << std::endl << std::endl;
 }

--- a/gtplib/detail/gtpengine_impl.hpp
+++ b/gtplib/detail/gtpengine_impl.hpp
@@ -29,6 +29,7 @@ struct Helper <void>
   void handle(Engine& engine, ProtocolCodec& codec, const Cmd& cmd)
   {
     engine.handle (cmd);
+    codec.writeResponse("");
   }
 };
 

--- a/gtplib/gtpengine.hpp
+++ b/gtplib/gtpengine.hpp
@@ -22,6 +22,7 @@ struct IEngine
   virtual void handle (const CmdClearBoard& cmd) = 0;
   virtual void handle (const CmdKomi& cmd) = 0;
   virtual VertexOrPass handle (const CmdGenmove& cmd) = 0;
+  virtual void handle (const CmdUndo& cmd) = 0;
   virtual void handle (const CmdPlay& cmd) = 0;
   virtual std::list<Vertex> handle (const CmdFixedHandicap& cmd) = 0;
   virtual std::list<Vertex> handle (const CmdPlaceFreeHandicap& cmd) = 0;
@@ -30,6 +31,7 @@ struct IEngine
   virtual void handle (const CmdTimeLeft& cmd) = 0;
   virtual void handle (const CmdFinalScore& cmd) = 0;
   virtual std::list<Vertex> handle (const CmdFinalStatusList& cmd) = 0;
+  virtual void handle (const CmdError& cmd) = 0;
 
   virtual ~IEngine () { /* do nothing */ }
 };

--- a/gtplib/gtptypes.hpp
+++ b/gtplib/gtptypes.hpp
@@ -24,7 +24,7 @@ struct VertexOrPass {
   operator Vertex() { return vertex; }
 };
 
-VertexOrPass Pass() { return VertexOrPass{}; }
+static inline VertexOrPass Pass() { return VertexOrPass{}; }
 
 // A player's move
 struct Move { Color color; VertexOrPass vertex; };
@@ -51,32 +51,32 @@ struct Command
 
 // equality operator for commands
 template<CommandType t, typename ReturnType, typename... Params>
-bool operator==(const Command<t, ReturnType, Params...>& c1,
+static inline bool operator==(const Command<t, ReturnType, Params...>& c1,
                 const Command<t, ReturnType, Params...>& c2)
 {
   return c1.params == c2.params;
 }
 
 // equality operator for Vertex
-bool operator==(const Vertex& v1, const Vertex& v2)
+static inline bool operator==(const Vertex& v1, const Vertex& v2)
 {
   return v1.x == v2.x && v1.y == v2.y;
 }
 
 // equality operator for VertexOrPass
-bool operator==(const VertexOrPass& v1, const VertexOrPass& v2)
+static inline bool operator==(const VertexOrPass& v1, const VertexOrPass& v2)
 {
   return v1.type == v2.type && v1.vertex == v2.vertex;
 }
 
 // equality operator for Move
-bool operator==(const Move& m1, const Move& m2)
+static inline bool operator==(const Move& m1, const Move& m2)
 {
   return m1.color == m2.color;
 }
 
 // equality operator for Score
-bool operator==(const Score& s1, const Score& s2)
+static inline bool operator==(const Score& s1, const Score& s2)
 {
   return (s1.advantage == 0 && s2.advantage == 0)
          || (s1.advantage == s2.advantage && s1.winner == s2.winner);


### PR DESCRIPTION
1. `std::tuple_size` is defined in `<tuple>` header
2. `param` is a non-static data member. Although C++11 allows `decltype(Command::params)`, it seems that Clang++ has a bug in this case, so workaround like `decltype(declval<Command>().params)` is required.
3. `cmd.params;` here seems redundant. 

Tested on Clang3.8 / gcc 6.2.1
